### PR TITLE
Blueshield rearm

### DIFF
--- a/modular_skyrat/modules/blueshield/code/blueshield.dm
+++ b/modular_skyrat/modules/blueshield/code/blueshield.dm
@@ -54,7 +54,10 @@
 	ears = /obj/item/radio/headset/headset_bs/alt
 	glasses = /obj/item/clothing/glasses/hud/security/sunglasses
 	backpack_contents = list(
-		/obj/item/storage/box/gunset/blueshield = 1,
+		// FLUFFY FRONTIER EDIT BEGIN
+		// Original line: /obj/item/storage/box/gunset/blueshield = 1,
+		/obj/item/storage/box/gunset/blueshield_advanced = 1,
+		// FLUFFY FRONTIER EDIT END
 	)
 	implants = list(/obj/item/implant/mindshield)
 	backpack = /obj/item/storage/backpack/blueshield

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6907,4 +6907,5 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\sentinel.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\spitter.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
+#include "~ff\blueshield_rearm\code\blueshield_weapons.dm"
 // END_INCLUDE

--- a/~ff/blueshield_rearm/code/blueshield_weapons.dm
+++ b/~ff/blueshield_rearm/code/blueshield_weapons.dm
@@ -1,0 +1,12 @@
+/obj/item/storage/box/gunset/blueshield_advanced
+	name = "Blueshield's gunset"
+	w_class = WEIGHT_CLASS_NORMAL
+
+/obj/item/storage/box/gunset/blueshield_advanced/PopulateContents()
+	. = ..()
+	new /obj/item/gun/ballistic/automatic/pistol/pdh/alt/nomag(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/ammo_box/magazine/multi_sprite/pdh(src)
+	new /obj/item/gun/energy/e_gun(src)


### PR DESCRIPTION
## About The Pull Request

Вместо ЦМГ щит теперь будет получать Соком и Аллстар.

## How This Contributes To The Skyrat Roleplay Experience

ЦМГ после нёрфов стал крайне сомнительным оружием которое, как я считаю, не подходит тому, кто должен давать отпор угрозе для глав здесь и сейчас. В замен этой пугалки я дал Щиту пистолет Соком, ввиду его элегантности и малого магазина, который не даст БЩ идти напролом в бой. А также сверху новое снаряжение я приправил еганом "Аллстар", который идеально подойдёт как вторичное оружие, ввиду слабой мощности и заряда, которое в основном будет использоваться ради нелетальных задержаний угрозы главам или самих глав (а ещё у него спрайт сасный).

## Proof of Testing

Не вижу смысла в пруфах, ибо все изменения более чем ясны и через код.

## Changelog

:cl:
balance: Blueshield got a decent armament.
/:cl:
