### PR TITLE
Auto accent

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -1054,3 +1054,6 @@ Remember to update _globalvars/traits.dm if you're adding/removing/renaming trai
 #define SPEAKING_FROM_TONGUE "tongue"
 ///trait source that sign language should use
 #define SPEAKING_FROM_HANDS "hands"
+
+//FF add, for auto-accent
+#define TRAIT_NO_ACCENT "has_auto_accent"

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -78,6 +78,9 @@
 	SIGNAL_HANDLER
 	if(speech_args[SPEECH_LANGUAGE] in languages_native)
 		return FALSE //no changes
+	// FF add, for auto-accent
+	if(HAS_TRAIT(source, TRAIT_NO_ACCENT))
+		return FALSE //accent disabled by user.
 	modify_speech(source, speech_args)
 
 /obj/item/organ/internal/tongue/proc/modify_speech(datum/source, list/speech_args)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -93,6 +93,8 @@
 	ADD_TRAIT(tongue_owner, TRAIT_SPEAKS_CLEARLY, SPEAKING_FROM_TONGUE)
 	if (modifies_speech)
 		RegisterSignal(tongue_owner, COMSIG_MOB_SAY, PROC_REF(handle_speech))
+		//FF add: verb to modify auto-accent
+		tongue_owner.verbs += /mob/living/proc/toggle_autoaccent
 
 	/* This could be slightly simpler, by making the removal of the
 	* NO_TONGUE_TRAIT conditional on the tongue's `sense_of_taste`, but
@@ -108,6 +110,10 @@
 	REMOVE_TRAIT(tongue_owner, TRAIT_SPEAKS_CLEARLY, SPEAKING_FROM_TONGUE)
 	temp_say_mod = ""
 	UnregisterSignal(tongue_owner, COMSIG_MOB_SAY)
+
+	//FF add: verb to modify auto-accent
+	tongue_owner.verbs -= /mob/living/proc/toggle_autoaccent
+
 	REMOVE_TRAIT(tongue_owner, TRAIT_AGEUSIA, ORGAN_TRAIT)
 	// Carbons by default start with NO_TONGUE_TRAIT caused TRAIT_AGEUSIA
 	ADD_TRAIT(tongue_owner, TRAIT_AGEUSIA, NO_TONGUE_TRAIT)

--- a/modular_skyrat/modules/customization/modules/client/augment/organs.dm
+++ b/modular_skyrat/modules/customization/modules/client/augment/organs.dm
@@ -93,3 +93,13 @@
 /datum/augment_item/organ/tongue/forked
 	name = "Forked tongue"
 	path = /obj/item/organ/internal/tongue/lizard
+
+//FF add, for auto-accent for anthropomorphs
+/datum/augment_item/organ/tongue/cat
+	name = "Cat tongue"
+	path = /obj/item/organ/internal/tongue/cat
+
+/datum/augment_item/organ/tongue/dog
+	name = "Dog tongue"
+	path = /obj/item/organ/internal/tongue/dog
+//FF add ends.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6937,4 +6937,5 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\sentinel.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\spitter.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
+#include "~ff\modules\autoaccent\code\tongue.dm"
 // END_INCLUDE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -6937,5 +6937,5 @@
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\sentinel.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\spitter.dm"
 #include "modular_skyrat\modules\xenos_skyrat_redo\code\xeno_types\warrior.dm"
-#include "~ff\modules\autoaccent\code\tongue.dm"
+#include "~ff\modules\autoaccent\code\autoaccent.dm"
 // END_INCLUDE

--- a/~ff/modules/autoaccent/code/autoaccent.dm
+++ b/~ff/modules/autoaccent/code/autoaccent.dm
@@ -1,0 +1,74 @@
+/client/verb/toggle_autoaccent()
+	set name = "Toggle Auto-Accent"
+	set desc = "Toggle automatic accents for your species"
+	set category = "IC"
+
+	if (mob == null)
+		to_chat("You cant toggle auto-accent in this state")
+	if (HAS_TRAIT(mob, TRAIT_NO_ACCENT))
+		REMOVE_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
+		to_chat(src, "Auto-accent is now on")
+	else
+		ADD_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
+		to_chat(src, "Auto-accent is now off")
+
+
+/obj/item/organ/internal/tongue/cat
+	modifies_speech = TRUE
+	languages_native = list(/datum/language/nekomimetic, /datum/language/yangyu, /datum/language/primitive_catgirl) //IDK, Yangyu is native to Felinids? WHY?
+
+/obj/item/organ/internal/tongue/cat/proc/pick_cat_rawr(match)
+	if (match[1] == "R")
+		return pick("Rr", "Rrr", "Rrrr")
+	return pick("rr", "rrr", "rrrr")
+
+/obj/item/organ/internal/tongue/cat/proc/pick_cat_rawr_RU(match)
+	if (match[1] == "Р")
+		return pick("Рр", "Ррр", "Рррр")
+	return pick("рр", "ррр", "рррр")
+
+/obj/item/organ/internal/tongue/cat/modify_speech(datum/source, list/speech_args)
+	var/message = speech_args[SPEECH_MESSAGE]
+	var/static/regex/cat_rawrs = new("r+", "g")
+	var/static/regex/cat_Rawrs = new("R+", "g")
+	if(message[1] != "*")
+		message = cat_rawrs.Replace(message,  PROC_REF(pick_cat_rawr))
+		message = cat_Rawrs.Replace(message,  PROC_REF(pick_cat_rawr))
+		if(CONFIG_GET(flag/russian_text_formation))
+			var/static/regex/cat_rawrs_RU = new("р+", "g")
+			var/static/regex/cat_Rawrs_RU = new("Р+", "g")
+			message = cat_rawrs_RU.Replace(message,  PROC_REF(pick_cat_rawr_RU))
+			message = cat_Rawrs_RU.Replace(message,  PROC_REF(pick_cat_rawr_RU))
+	speech_args[SPEECH_MESSAGE] = message
+
+/datum/species/vulpkanin
+	mutanttongue = /obj/item/organ/internal/tongue/dog
+
+/obj/item/organ/internal/tongue/dog
+	modifies_speech = TRUE
+	languages_native = list(/datum/language/canilunzt)
+
+/obj/item/organ/internal/tongue/dog/proc/pick_dog_rawr(match)
+	if (match[1] == "R")
+		return pick("R", "Rr", "Rrr")
+	return pick("r", "rr", "rrr")
+
+/obj/item/organ/internal/tongue/dog/proc/pick_dog_rawr_RU(match)
+	if (match[1] == "Р")
+		return pick("Р", "Рр", "Ррр")
+	return pick("р", "рр", "ррр")
+
+/obj/item/organ/internal/tongue/dog/modify_speech(datum/source, list/speech_args)
+	var/message = speech_args[SPEECH_MESSAGE]
+	var/static/regex/dog_rawrs = new("r+", "g")
+	var/static/regex/dog_Rawrs = new("R+", "g")
+	if(message[1] != "*")
+		message = dog_rawrs.Replace(message, PROC_REF(pick_dog_rawr))
+		message = dog_Rawrs.Replace(message, PROC_REF(pick_dog_rawr))
+		if(CONFIG_GET(flag/russian_text_formation))
+			var/static/regex/dog_rawrs_RU = new("р+", "g")
+			var/static/regex/dog_Rawrs_RU = new("Р+", "g")
+			message = dog_rawrs_RU.Replace(message, PROC_REF(pick_dog_rawr_RU))
+			message = dog_Rawrs_RU.Replace(message, PROC_REF(pick_dog_rawr_RU))
+	speech_args[SPEECH_MESSAGE] = message
+

--- a/~ff/modules/autoaccent/code/autoaccent.dm
+++ b/~ff/modules/autoaccent/code/autoaccent.dm
@@ -3,7 +3,7 @@
 	set desc = "Toggle automatic accents for your species"
 	set category = "IC"
 
-	if (mob == null)
+	if (!mob)
 		to_chat("You cant toggle auto-accent in this state")
 	if (HAS_TRAIT(mob, TRAIT_NO_ACCENT))
 		REMOVE_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
@@ -12,33 +12,25 @@
 		ADD_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
 		to_chat(src, "Auto-accent is now off")
 
+//If there is build-in func?
+/proc/text_mult(text, count)
+	. = list()
+	while(count--)
+		. += text
+	return jointext(., "")
 
 /obj/item/organ/internal/tongue/cat
 	modifies_speech = TRUE
 	languages_native = list(/datum/language/nekomimetic, /datum/language/yangyu, /datum/language/primitive_catgirl) //IDK, Yangyu is native to Felinids? WHY?
 
 /obj/item/organ/internal/tongue/cat/proc/pick_cat_rawr(match)
-	if (match[1] == "R")
-		return pick("Rr", "Rrr", "Rrrr")
-	return pick("rr", "rrr", "rrrr")
-
-/obj/item/organ/internal/tongue/cat/proc/pick_cat_rawr_RU(match)
-	if (match[1] == "Р")
-		return pick("Рр", "Ррр", "Рррр")
-	return pick("рр", "ррр", "рррр")
+	return match[1] + text_mult(lowertext(match[1]), rand(1, 3))
 
 /obj/item/organ/internal/tongue/cat/modify_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	var/static/regex/cat_rawrs = new("r+", "g")
-	var/static/regex/cat_Rawrs = new("R+", "g")
+	var/static/regex/cat_rawrs = new(@"[рРrR]+", "g")
 	if(message[1] != "*")
 		message = cat_rawrs.Replace(message,  PROC_REF(pick_cat_rawr))
-		message = cat_Rawrs.Replace(message,  PROC_REF(pick_cat_rawr))
-		if(CONFIG_GET(flag/russian_text_formation))
-			var/static/regex/cat_rawrs_RU = new("р+", "g")
-			var/static/regex/cat_Rawrs_RU = new("Р+", "g")
-			message = cat_rawrs_RU.Replace(message,  PROC_REF(pick_cat_rawr_RU))
-			message = cat_Rawrs_RU.Replace(message,  PROC_REF(pick_cat_rawr_RU))
 	speech_args[SPEECH_MESSAGE] = message
 
 /datum/species/vulpkanin
@@ -49,26 +41,13 @@
 	languages_native = list(/datum/language/canilunzt)
 
 /obj/item/organ/internal/tongue/dog/proc/pick_dog_rawr(match)
-	if (match[1] == "R")
-		return pick("R", "Rr", "Rrr")
-	return pick("r", "rr", "rrr")
+	return match[1] + text_mult(lowertext(match[1]), rand(0, 2))
 
-/obj/item/organ/internal/tongue/dog/proc/pick_dog_rawr_RU(match)
-	if (match[1] == "Р")
-		return pick("Р", "Рр", "Ррр")
-	return pick("р", "рр", "ррр")
-
+// Almost same as /obj/item/organ/internal/tongue/cat/modify_speech. Maybe there is way to uniform replaces for any tongue with maps.
 /obj/item/organ/internal/tongue/dog/modify_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	var/static/regex/dog_rawrs = new("r+", "g")
-	var/static/regex/dog_Rawrs = new("R+", "g")
+	var/static/regex/dog_rawrs = new(@"[рРrR]+", "g")
 	if(message[1] != "*")
-		message = dog_rawrs.Replace(message, PROC_REF(pick_dog_rawr))
-		message = dog_Rawrs.Replace(message, PROC_REF(pick_dog_rawr))
-		if(CONFIG_GET(flag/russian_text_formation))
-			var/static/regex/dog_rawrs_RU = new("р+", "g")
-			var/static/regex/dog_Rawrs_RU = new("Р+", "g")
-			message = dog_rawrs_RU.Replace(message, PROC_REF(pick_dog_rawr_RU))
-			message = dog_Rawrs_RU.Replace(message, PROC_REF(pick_dog_rawr_RU))
+		message = dog_rawrs.Replace(message,  PROC_REF(pick_dog_rawr))
 	speech_args[SPEECH_MESSAGE] = message
 

--- a/~ff/modules/autoaccent/code/autoaccent.dm
+++ b/~ff/modules/autoaccent/code/autoaccent.dm
@@ -1,16 +1,16 @@
-/client/verb/toggle_autoaccent()
+/mob/living/proc/toggle_autoaccent()
 	set name = "Toggle Auto-Accent"
 	set desc = "Toggle automatic accents for your species"
 	set category = "IC"
 
-	if (!mob)
+	if (!src)
 		to_chat("You cant toggle auto-accent in this state")
-	if (HAS_TRAIT(mob, TRAIT_NO_ACCENT))
-		REMOVE_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
-		to_chat(src, "Auto-accent is now on")
+	if (HAS_TRAIT(src, TRAIT_NO_ACCENT))
+		REMOVE_TRAIT(src, TRAIT_NO_ACCENT, "ooc_verb")
+		to_chat(src.client, "Auto-accent is now on")
 	else
-		ADD_TRAIT(mob, TRAIT_NO_ACCENT, "ooc_verb")
-		to_chat(src, "Auto-accent is now off")
+		ADD_TRAIT(src, TRAIT_NO_ACCENT, "ooc_verb")
+		to_chat(src.client, "Auto-accent is now off")
 
 //If there is build-in func?
 /proc/text_mult(text, count)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Авто-акцент для фелинидов, таяр, вульп и всех тех, кто использует кошачий/собачий биологический язык.

## How This Contributes To The Skyrat Roleplay Experience

<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->
Добавляет автоматический акцент, привязанный к типу языка для котоподобных и собакоподобных существ. Через verb во вкладке IC можно отключить эту фичу.

## Proof of testing
<details>
<summary>Примеры: </summary>

Фелинид мурчит с включеным авто-акцентом
![image](https://user-images.githubusercontent.com/6696374/232249130-da2e63c2-440a-4ebe-a4a0-e39476f8a8d7.png)

Фелинид мурчит с выключеным авто-акцентом
![image](https://user-images.githubusercontent.com/6696374/232249195-f3bcfa70-7d70-471d-b870-3e47505d4369.png)

Вульпа рычит с включенным авто-акцентом
![image](https://user-images.githubusercontent.com/6696374/232249220-8f2b3bd5-76b2-42b4-b037-3c1ff9be7e8c.png)

Вульпа рычит с выключенным авто-акцентом
![image](https://user-images.githubusercontent.com/6696374/232249237-8b81f7df-a852-43d5-9cf3-626c01ebbaf2.png)

Языки в меню настройки персонажа
![image](https://user-images.githubusercontent.com/6696374/232249272-17fa7149-1f00-408e-a149-680d4b23fd12.png)

</details>

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: added auto-accent for vulpkanins, tajarans and felinids and anthromorphs.
qol: any auto-accent can be disabled with IC -> Toggle auto-accent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
