### PR TITLE
Newspaper utf-8 charset fix

### DIFF
--- a/code/game/machinery/newscaster/newspaper.dm
+++ b/code/game/machinery/newscaster/newspaper.dm
@@ -36,6 +36,12 @@
 	if(!istype(user) || !user.can_read(src))
 		return
 	var/dat
+	//FF ADD BEGIN
+	//513 has utf-8 support.
+	//This could still break when text (ciryllic) is written to newscaster
+	//with the windows-1251 encoding, but this should not happen
+	dat+="<meta charset=\"utf-8\">"
+	//FF ADD END
 	pages = 0
 	switch(screen)
 		if(0) //Cover


### PR DESCRIPTION
![изображение](https://user-images.githubusercontent.com/15817985/233866212-0944516f-4292-4ad2-b22c-7951bd0d3f16.png)
## Changelog

:cl:
fix: at now utf-8 newspapers
/:cl:


