### PR TITLE
MCR restoration

### DIFF
--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -16,7 +16,7 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	maxcharge = 1200 //12 shots
 	chargerate = 0 //MF cells should be unable to recharge if they are not currently inside of an MCR
 	microfusion_readout = TRUE
-	empty = FLASE // FLUFFY FRONTIER EDIT. ORIGINAL VALUE: TRUE //MF cells should start empty
+	empty = FALSE // FLUFFY FRONTIER EDIT. ORIGINAL VALUE: TRUE //MF cells should start empty
 
 	/// A hard referenced list of upgrades currently attached to the weapon.
 	var/list/attachments = list()

--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -155,10 +155,14 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	chargerate = 300
 
 /obj/item/stock_parts/cell/microfusion/proc/cell_removal_discharge()
+	// FLUFFY FRONTIER EDIT: REMOVAL BEGIN - MCR FIX
+	/*
 	chargerate = 0
 	charge = 0
 	do_sparks(4, FALSE, src)
 	update_appearance()
+	*/
+	// FLUFFY FRONTIER EDIT: REMOVAL END
 
 /datum/crafting_recipe/makeshift/microfusion_cell
 	name = "Makeshift Microfusion Cell"

--- a/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_cell.dm
@@ -16,7 +16,7 @@ Essentially, power cells that malfunction if not used in an MCR, and should only
 	maxcharge = 1200 //12 shots
 	chargerate = 0 //MF cells should be unable to recharge if they are not currently inside of an MCR
 	microfusion_readout = TRUE
-	empty = TRUE //MF cells should start empty
+	empty = FLASE // FLUFFY FRONTIER EDIT. ORIGINAL VALUE: TRUE //MF cells should start empty
 
 	/// A hard referenced list of upgrades currently attached to the weapon.
 	var/list/attachments = list()

--- a/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
+++ b/modular_skyrat/modules/microfusion/code/microfusion_energy_master.dm
@@ -565,9 +565,15 @@
 	if(cell)
 		hotswap = TRUE
 	var/obj/item/stock_parts/cell/old_cell = cell
+	
+	// FLUFFY FRONTIER EDIT: REMOVAL BEGIN - MCR FIX
+	/*
 	if(inserting_cell.charge)
 		balloon_alert(user, "can't insert a charged cell!")
 		return FALSE
+	*/
+	// FLUFFY FRONTIER EDIT: REMOVAL END
+	
 	if(display_message)
 		balloon_alert(user, "cell inserted")
 	if(hotswap)


### PR DESCRIPTION
## About The Pull Request

Возвращает возможность перезаряжать МКРы, делая их вновь серьёзным оружием, которое можно использовать.

## How This Contributes To The Skyrat Roleplay Experience

МКРы были покинуты офицерами из-за своей малой боевой нагрузки, время это исправить.

## Proof of Testing

<details>
<summary>Screenshots/Videos</summary>

![dreamseeker_4QVvB4z9cu](https://user-images.githubusercontent.com/121913313/234623483-5417048a-6cf9-48d7-8b08-fc4120cea279.gif)
  
</details>

## Changelog

:cl:
balance: MCR now can be reloaded!
/:cl:
