### PR TITLE
Teshari with human's hats fix.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -550,6 +550,10 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 
 /mob/living/carbon/human/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
 	..()
+	// FLUFFY FRONTIER EDIT: ADDITION BEGIN
+	if(mrace == SPECIES_TESHARI) // Not for all species. Only for Teshari. I dont care about other species with that trouble!
+		RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(teshari_rotate))
+	// FLUFFY FRONTIER EDIT: ADDITION END
 	if(icon_update)
 		update_body(is_creating = TRUE)
 		update_mutations_overlay()// no lizard with human hulk overlay please.

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -551,7 +551,7 @@ GLOBAL_LIST_INIT(total_uf_len_by_block, populate_total_uf_len_by_block())
 /mob/living/carbon/human/set_species(datum/species/mrace, icon_update = TRUE, pref_load = FALSE)
 	..()
 	// FLUFFY FRONTIER EDIT: ADDITION BEGIN
-	if(mrace == SPECIES_TESHARI) // Not for all species. Only for Teshari. I dont care about other species with that trouble!
+	if(mrace == /datum/species/teshari)// Not for all species. Only for Teshari. I dont care about other species with that trouble!
 		RegisterSignal(src, COMSIG_ATOM_DIR_CHANGE, PROC_REF(teshari_rotate))
 	// FLUFFY FRONTIER EDIT: ADDITION END
 	if(icon_update)

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -433,11 +433,11 @@ There are several things that need to be remembered:
 			// Original line: head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
 			// FLUFFY FRONTIER EDIT: REMOVAL END
 			// FLUFFY FRONTIER EDIT: ADDITION BEGIN
-			if(isteshari(src)) // Its help us to deal with offset hats on different dirrections!
+			if(isteshari(src))// Its help us to deal with offset hats on different dirrections!
 				switch(src.dir)
-					if(EAST|SOUTH|NORTH)
+					if(EAST, SOUTHEAST, NORTHEAST)
 						head_overlay.pixel_x += (dna.species.offset_features[OFFSET_HEAD][1])
-					if(WEST|SOUTHEAST|NORTHWEST)
+					if(WEST, SOUTHWEST, NORTHWEST)
 						head_overlay.pixel_x += (dna.species.offset_features[OFFSET_HEAD][1] - 2)
 			else
 				head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]

--- a/code/modules/mob/living/carbon/human/human_update_icons.dm
+++ b/code/modules/mob/living/carbon/human/human_update_icons.dm
@@ -429,7 +429,19 @@ There are several things that need to be remembered:
 		var/mutable_appearance/head_overlay = head.build_worn_icon(default_layer = HEAD_LAYER, default_icon_file = icon_file, override_file = mutant_override ? icon_file : null) // SKYRAT EDIT CHANGE
 
 		if(!mutant_override && (OFFSET_HEAD in dna.species.offset_features)) // SKYRAT EDIT CHANGE
-			head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
+			// FLUFFY FRONTIER EDIT: REMOVAL
+			// Original line: head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
+			// FLUFFY FRONTIER EDIT: REMOVAL END
+			// FLUFFY FRONTIER EDIT: ADDITION BEGIN
+			if(isteshari(src)) // Its help us to deal with offset hats on different dirrections!
+				switch(src.dir)
+					if(EAST|SOUTH|NORTH)
+						head_overlay.pixel_x += (dna.species.offset_features[OFFSET_HEAD][1])
+					if(WEST|SOUTHEAST|NORTHWEST)
+						head_overlay.pixel_x += (dna.species.offset_features[OFFSET_HEAD][1] - 2)
+			else
+				head_overlay.pixel_x += dna.species.offset_features[OFFSET_HEAD][1]
+			// FLUFFY FRONTIER EDIT: ADDITION END
 			head_overlay.pixel_y += dna.species.offset_features[OFFSET_HEAD][2]
 		overlays_standing[HEAD_LAYER] = head_overlay
 

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -84,8 +84,8 @@
 // FLUFFY FRONTIER EDIT: ADDITION BEGIN
 /mob/living/carbon/human/proc/teshari_rotate(atom/source, dir, newdir) // This proc helps to handle the signal.
 	SIGNAL_HANDLER // dna.dm set_species()
-	if(dir==newdir) // Occur the spam of other procs.
+	if(newdir == 0 || dir == newdir) // Occur the spam of our proc.
 		return
-	remove_overlay(HEAD_LAYER)
+	src.dir = newdir // Actually it brokes nothing. But dont make shitcode like that again.
 	update_worn_head()
 // FLUFFY FRONTIER EDIT: ADDITION END

--- a/modular_skyrat/modules/teshari/code/_teshari.dm
+++ b/modular_skyrat/modules/teshari/code/_teshari.dm
@@ -81,3 +81,11 @@
 	tesh.dna.mutant_bodyparts["tail"] = list(MUTANT_INDEX_NAME = "Teshari (Default)", MUTANT_INDEX_COLOR_LIST = list(base_color, base_color, ear_color))
 	regenerate_organs(tesh, src, visual_only = TRUE)
 	tesh.update_body(TRUE)
+// FLUFFY FRONTIER EDIT: ADDITION BEGIN
+/mob/living/carbon/human/proc/teshari_rotate(atom/source, dir, newdir) // This proc helps to handle the signal.
+	SIGNAL_HANDLER // dna.dm set_species()
+	if(dir==newdir) // Occur the spam of other procs.
+		return
+	remove_overlay(HEAD_LAYER)
+	update_worn_head()
+// FLUFFY FRONTIER EDIT: ADDITION END


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
### **Дело в шляпе.** 

На тешарьках откровенно плохо рисовались людские шляпки. Причина этому - отсутствие раздельной обработки оверлеев самих шляпок. Как я понял, изучая код, смещение шляпок идет для всего спрайта шляпки. Из-за чего не было возможности обработать данный момент без костылей для разных направлений(юг, запад, восток, север). 

1 костыль: проверка существ на "тешарьность" и выдачу тем сигнала на активацию процедуры teshari_rotate и повторной отрисовки шляпки. 

2 костыль: так как у нас не было сигнала, что бы вызывался ПОСЛЕ смены директории atom, мы осторожно прописываем в процедуре teshari_rotate наш костылёк src.dir = newdir. Таким образом мы избегаем глобальных изменений в коде.

Well... Пока это единственное решение данного недуга. И оно корректно работает. 

Если есть идеи как подправить или реализовать иначе - пишем. Исправим. 
 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## How This Contributes To The ~~Skyrat~~ Fluffy Frontier Roleplay Experience

Я смогу бегать в каске инженера и не блевать от того, что при движении на запад у тешарек съезжает каска. 
<!-- Please add a short description of why you think these changes would benefit the game and the roleplay atmosphere of the server. If you can't justify it in words, it might not be worth adding. -->

## Proof of Testing
### Before:
![before6](https://user-images.githubusercontent.com/33174229/235708077-619f9a97-12cd-4f85-bfdd-40c55650b164.png) ![before5](https://user-images.githubusercontent.com/33174229/235708128-455da711-e676-446b-9325-495cfc0cf63f.png) ![before3](https://user-images.githubusercontent.com/33174229/235708160-912ab389-4ca1-4908-b823-3e349a6d4ba2.png) ![before4](https://user-images.githubusercontent.com/33174229/235708133-61764b33-6bda-4729-9d2c-c490ac7793d4.png) ![before2](https://user-images.githubusercontent.com/33174229/235708211-28117aa8-53ed-42ac-a29e-47ca7fa87e2b.png) ![before1](https://user-images.githubusercontent.com/33174229/235708231-29f55200-8d0f-46fe-a1b2-dbc61ee92513.png)

### After:
![after2](https://user-images.githubusercontent.com/33174229/235708281-a4cb2357-1f11-4310-904f-e70458c58538.png) ![after](https://user-images.githubusercontent.com/33174229/235708298-2b0423dc-b988-4133-b6a1-1143418ac05a.png) ![after6](https://user-images.githubusercontent.com/33174229/235708366-0f346afb-bcb5-4264-b143-3787847e289d.png) ![after5](https://user-images.githubusercontent.com/33174229/235708379-c7276647-a152-4aee-8ec3-6fd6b229a071.png) ![after3](https://user-images.githubusercontent.com/33174229/235708330-aed0b4ad-d8ca-484d-936e-e21a67c6aa7e.png) ![after4](https://user-images.githubusercontent.com/33174229/235708343-6314f336-7d99-4211-bc4d-a1ad7ff7f7fb.png) 

<!-- Include any screenshots/videos/debugging steps of the code functioning successfully, between the </summary> and </details> code blocks. -->
<!-- To our mappers and spriters: Posting screenshots of content INSIDE EDITORS (aseprite, PDN, SDMM, ect) is NOT valid proof of testing. Please make sure that you COMPILE the game and provide PROOF you tested your edits. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed human's hats on teshari
code: changed some SkyRat code
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
