### PR TITLE
Поддержка русского языка при отправке оповещения через консоли запросов (requests_console).

### DIFF
--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -311,7 +311,10 @@ GLOBAL_LIST_EMPTY(req_console_ckey_departments)
 			priority = clamp(text2num(href_list["priority"]), REQ_NORMAL_MESSAGE_PRIORITY, REQ_EXTREME_MESSAGE_PRIORITY)
 
 	if(href_list["writeAnnouncement"])
-		var/new_message = reject_bad_text(tgui_input_text(usr, "Write your message", "Awaiting Input"))
+		// FLUFFY FRONTIER EDIT BEGIN - Russian text in announcement fix.
+		// ORIGINAL LINE: var/new_message = reject_bad_text(tgui_input_text(usr, "Write your message", "Awaiting Input"))
+		var/new_message = reject_bad_text(tgui_input_text(usr, "Write your message", "Awaiting Input"), ascii_only = FALSE)
+		// FLUFFY FRONTIER EDIT END
 		if(new_message)
 			message = new_message
 			priority = clamp(text2num(href_list["priority"]) || REQ_NORMAL_MESSAGE_PRIORITY, REQ_NORMAL_MESSAGE_PRIORITY, REQ_EXTREME_MESSAGE_PRIORITY)


### PR DESCRIPTION
## Описание данного ПРа

Собственно, ПР добавит возможность отсылать оповещения на русском языке через консоли запросов. 

Почему заливаю сюда, а не на ТГ? Причина проста: Пока они там примут (а могут и покапризничать), и пока это дойдёт до крыс, а в последствии и до нас - пройдёт целая вечность. Как вариант - можно пока вмержить и использовать этот фикс на нашем проекте, пока аналогичный фикс будет на рассмотрении ТГшеров.

Пруф оф тестинг типа:

![dreamseeker_KyuZF8Q1iN](https://github.com/Fluffy-Frontier/Fluffy-STG/assets/121913313/a4320d11-ec24-4420-8519-5e458b20ba86)

## Changelog

:cl:
fix: Теперь в консолях запросов (requests_console)  можно отправлять оповещения с русским текстом.
/:cl:
